### PR TITLE
Update replicaset command and values

### DIFF
--- a/templates/ckan/replicaset.yaml
+++ b/templates/ckan/replicaset.yaml
@@ -22,11 +22,8 @@ spec:
             - name: production-ini
               mountPath: /config
               readOnly: true
-          command:
-            - ckan
-            - run
-            - --host
-            - "0.0.0.0"
+          command: ["/bin/sh", "-c"]
+          args: ["/ckan-entrypoint.sh && ckan run --host 0.0.0.0"]
           env:
             {{- with .Values.ckan.config }}
             - name: CKAN_SQLALCHEMY_URL
@@ -34,15 +31,10 @@ spec:
                 secretKeyRef:
                   name: {{ .sqlalchemyUrlSecretKeyRef.name }}
                   key: {{ .sqlalchemyUrlSecretKeyRef.key }}
+            - name: CKAN_DB_HOST
+              value: {{ print $.Release.Name "-postgres" }}
             - name: CKAN_SOLR_URL
               value: {{ .solr.url | default (print "http://" $.Release.Name "-solr/solr/ckan") }}
-            #- name: CKAN_SOLR_USER
-            #  value: {{ .solr.user }}
-            #- name: CKAN_SOLR_PASSWORD
-            #  valueFrom:
-            #    secretKeyRef:
-            #      name: {{ .solr.passwordSecretKeyRef.name }}
-            #      key: {{ .solr.passwordSecretKeyRef.key }}
             - name: CKAN_SITE_ID
               value: {{ .site.id }}
             - name: CKAN_SITE_URL
@@ -60,10 +52,30 @@ spec:
                   key: {{ .smtp.passwordSecretKeyRef.key }}
             - name: CKAN_SMTP_MAIL_FROM
               value: {{ .smtp.mailFrom }}
+            - name: CKAN_CONFIG
+              value: /config/
             - name: CKAN_INI
               value: /config/production.ini
             - name: CKAN_REDIS_URL
               value: redis://{{ .redis.host | default (print $.Release.Name "-redis") }}/{{ .redis.db_number | default "1" }}
+
+              {{- if .Values.dev.enabled }}
+            - name: CKAN_TEST_SYSADMIN_NAME
+              value: ckan_admin_test
+            - name: CKAN_TEST_SYSADMIN_PASSWORD
+              value: test1234
+            - name: CKAN_SYSADMIN_NAME
+              value: ckan_admin
+            - name: CKAN_SYSADMIN_EMAIL
+              value: ckan_admin@localhost
+            - name: CKAN_SYSADMIN_PASSWORD
+              value: test1234
+            - name: CREATE_CKAN_ADMIN
+              value: "1"
+            - name: SETUP_DGU_TEST_DATA
+              value: "1"
+              {{- end }}
+
             {{- end }}
       volumes:
         - name: production-ini

--- a/values.yaml
+++ b/values.yaml
@@ -58,3 +58,5 @@ ingress:
   enabled: false
   ingressClassName: tbd
   annotations: []
+dev:
+  enabled: false


### PR DESCRIPTION
Call the ckan-entrypoint.sh directly and run CKAN as the helm command will override any docker entrypoint scripts.

Also add env vars to automate the setup of CKAN for testing locally