### PR TITLE
Add pycsw

### DIFF
--- a/super-secret.yaml
+++ b/super-secret.yaml
@@ -7,6 +7,7 @@ stringData:
   sqlalchemy_url: "postgresql://ckan:ckan@ckan-test-postgres/ckan"
   solr_password: "ckan"
   smtp_password: "ckan"
+  beaker_session_secret: "9EZiPwkeS+cZpqb0VDWrN+Q0M"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/super-secret.yaml
+++ b/super-secret.yaml
@@ -8,6 +8,8 @@ stringData:
   solr_password: "ckan"
   smtp_password: "ckan"
   beaker_session_secret: "9EZiPwkeS+cZpqb0VDWrN+Q0M"
+  aws_access_key_id: "test"
+  aws_secret_access_key: "test"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/templates/_env_vars.tpl
+++ b/templates/_env_vars.tpl
@@ -6,7 +6,7 @@
       name: {{ .sqlalchemyUrlSecretKeyRef.name }}
       key: {{ .sqlalchemyUrlSecretKeyRef.key }}
 - name: CKAN_DB_HOST
-  value: {{ print $.Release.Name "-postgres" }}
+  value: {{ .dbHost | default (print $.Release.Name "-postgres") }}
 - name: CKAN_SOLR_URL
   value: {{ .solr.url | default (print "http://" $.Release.Name "-solr/solr/ckan") }}
 - name: CKAN_SITE_ID
@@ -48,5 +48,17 @@
 - name: SETUP_DGU_TEST_DATA
   value: "1"
   {{- end }}
+{{- if not .s3.useIamServiceAccount }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .s3.credentials.awsAccessKeyIdSecretKeyRef.name }}
+      key: {{ .s3.credentials.awsAccessKeyIdSecretKeyRef.key }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .s3.credentials.awsSecretAccessKeySecretKeyRef.name }}
+      key: {{ .s3.credentials.awsSecretAccessKeySecretKeyRef.key }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/_pycsw.tpl
+++ b/templates/_pycsw.tpl
@@ -1,0 +1,40 @@
+{{- define "ckan.pycsw-init" -}}
+initContainers:
+  - name: config-set
+    image: {{ .Values.ckan.image }}
+    command: [ "/bin/sh", "-c", '. /init/init.sh']
+    imagePullPolicy: Always
+    env:
+      {{- include "ckan.environment-variables" . | nindent 6 }}
+      - name: CKAN_BEAKER_SESSION_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
+            key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
+    volumeMounts:
+      - name: pycsw-cfg
+        mountPath: /pycsw
+        readOnly: true
+      - name: production-ini
+        mountPath: /map
+        readOnly: true
+      - name: config
+        mountPath: /config
+      - name: pycsw-init
+        mountPath: /init
+{{- end }}
+
+{{- define "ckan.pycsw-volumes" -}}
+volumes:
+  - name: pycsw-cfg
+    configMap:
+      name: {{ .Release.Name }}-pycsw-cfg
+  - name: pycsw-init
+    configMap:
+      name: {{ .Release.Name }}-pycsw-init
+  - name: production-ini
+    configMap:
+      name: {{ .Release.Name }}-ckan-production-ini
+  - name: config
+    emptyDir: {}
+{{- end }}

--- a/templates/_pycsw.tpl
+++ b/templates/_pycsw.tpl
@@ -1,7 +1,7 @@
 {{- define "ckan.pycsw-init" -}}
 initContainers:
   - name: config-set
-    image: {{ .Values.ckan.image }}
+    image: {{ .Values.pycsw.image }}
     command: [ "/bin/sh", "-c", '. /init/init.sh']
     imagePullPolicy: Always
     env:

--- a/templates/ckan/configmap.yaml
+++ b/templates/ckan/configmap.yaml
@@ -98,6 +98,8 @@ data:
     ckan.harvest.mq.port = {{ .Values.ckan.config.redis.port | default "6379" }}
     ckan.harvest.mq.redis_db = {{ .Values.ckan.config.redis.db_number | default "1" }}
     
+    ckan.redis.url = redis://{{ .Values.ckan.config.redis.host | default (print .Release.Name "-redis") }}:{{ .Values.ckan.config.redis.port | default "6379" }}/{{ .Values.ckan.config.redis.db_number | default "1" }}
+
     ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
     ckan.spatial.validator.reject = true
     
@@ -145,11 +147,9 @@ data:
     #ckan.max_image_size = 2
     
     ## S3 Settngs
-    ckan.datagovuk.s3_aws_access_key_id = xx
-    ckan.datagovuk.s3_aws_secret_access_key = xx
-    ckan.datagovuk.s3_bucket_name = {{ .Values.ckan.config.s3.bucket_name }}
-    ckan.datagovuk.s3_url_prefix = {{ .Values.ckan.config.s3.url_prefix }}
-    ckan.datagovuk.s3_aws_region_name = {{ .Values.ckan.config.s3.region_name }}
+    ckan.datagovuk.s3_bucket_name = {{ .Values.ckan.config.s3.bucketName }}
+    ckan.datagovuk.s3_url_prefix = {{ .Values.ckan.config.s3.urlPrefix }}
+    ckan.datagovuk.s3_aws_region_name = {{ .Values.ckan.config.s3.regionName }}
     
     ## CKAN 2.9 settings
     ckan.route_after_login = dashboard.datasets

--- a/templates/ckan/configmap.yaml
+++ b/templates/ckan/configmap.yaml
@@ -148,6 +148,8 @@ data:
     #ckan.max_image_size = 2
     
     ## S3 Settngs
+    ckan.datagovuk.s3_aws_access_key_id =
+    ckan.datagovuk.s3_aws_secret_access_key =
     ckan.datagovuk.s3_bucket_name = {{ .Values.ckan.config.s3.bucketName }}
     ckan.datagovuk.s3_url_prefix = {{ .Values.ckan.config.s3.urlPrefix }}
     ckan.datagovuk.s3_aws_region_name = {{ .Values.ckan.config.s3.regionName }}

--- a/templates/ckan/configmap.yaml
+++ b/templates/ckan/configmap.yaml
@@ -124,6 +124,7 @@ data:
     #ckan.recaptcha.privatekey =
     #licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
     # ckan.template_footer_end =
+    ckan.group_and_organization_list_max = 2000
     
     
     ## Internationalisation Settings

--- a/templates/ckan/ingress.yaml
+++ b/templates/ckan/ingress.yaml
@@ -21,6 +21,13 @@ spec:
                 name: {{ $.Release.Name }}-ckan
                 port:
                   number: 5000
+          - path: /csw
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-pycsw
+                port:
+                  number: 8000
   {{- if .tls.enabled }}
   tls:
     - hosts:

--- a/templates/ckan/init-configmap.yaml
+++ b/templates/ckan/init-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ckan-init
+data:
+  init.sh: |
+    # copy production.ini
+    cp /map/production.ini /config
+
+    # update production.ini
+    ckan config-tool $CKAN_INI "beaker.session.secret=$CKAN_BEAKER_SESSION_SECRET"
+
+    {{- if $.Values.dev.enabled }}
+    ckan config-tool $CKAN_INI "ckan.datagovuk.s3_aws_access_key_id = $CKAN_AWS_ACCESS_KEY_ID"
+    ckan config-tool $CKAN_INI "ckan.datagovuk.s3_aws_secret_access_key = $CKAN_AWS_ACCESS_KEY_SECRET"
+    {{- end }}

--- a/templates/ckan/replicaset.yaml
+++ b/templates/ckan/replicaset.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-ckan
     spec:
+      {{- if .Values.ckan.serviceAccount.enabled }}serviceAccountName: ckan-service-account-{{ .Release.Name }}{{- end }}
       initContainers:
         - name: config-set
           image: {{ .Values.ckan.image }}

--- a/templates/ckan/replicaset.yaml
+++ b/templates/ckan/replicaset.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-ckan
     spec:
-      {{- if .Values.ckan.serviceAccount.enabled }}serviceAccountName: ckan-service-account-{{ .Release.Name }}{{- end }}
+      {{ if .Values.ckan.serviceAccount.enabled }}serviceAccountName: {{ .Values.ckan.serviceAccount.name | default (print "ckan-" .Release.Name) }}{{- end }}
       initContainers:
         - name: config-set
           image: {{ .Values.ckan.image }}

--- a/templates/ckan/replicaset.yaml
+++ b/templates/ckan/replicaset.yaml
@@ -16,7 +16,7 @@ spec:
       initContainers:
         - name: config-set
           image: {{ .Values.ckan.image }}
-          command: [ "/bin/sh", "-c", 'cp /map/production.ini /config && ckan config-tool $CKAN_INI "beaker.session.secret=$CKAN_BEAKER_SESSION_SECRET"']
+          command: [ "/bin/sh", "-c", '. /init/init.sh']
           imagePullPolicy: Always
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
@@ -25,12 +25,26 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
                   key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
+            {{- if $.Values.dev.enabled }}
+            - name: CKAN_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ckan.config.s3.credentials.awsAccessKeyIdSecretKeyRef.name }}
+                  key: {{ .Values.ckan.config.s3.credentials.awsAccessKeyIdSecretKeyRef.key }}
+            - name: CKAN_AWS_ACCESS_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ckan.config.s3.credentials.awsSecretAccessKeySecretKeyRef.name }}
+                  key: {{ .Values.ckan.config.s3.credentials.awsSecretAccessKeySecretKeyRef.key }}
+            {{- end }}
           volumeMounts:
             - name: production-ini
               mountPath: /map
               readOnly: true
             - name: config
               mountPath: /config
+            - name: ckan-init
+              mountPath: /init
       containers:
         - name: ckan
           image: {{ .Values.ckan.image }}
@@ -47,6 +61,9 @@ spec:
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
       volumes:
+        - name: ckan-init
+          configMap:
+            name: {{ .Release.Name }}-ckan-init
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-ckan-production-ini

--- a/templates/ckan/replicaset.yaml
+++ b/templates/ckan/replicaset.yaml
@@ -12,6 +12,24 @@ spec:
       labels:
         app: {{ .Release.Name }}-ckan
     spec:
+      initContainers:
+        - name: config-set
+          image: {{ .Values.ckan.image }}
+          command: [ "/bin/sh", "-c", 'cp /map/production.ini /config && ckan config-tool $CKAN_INI "beaker.session.secret=$CKAN_BEAKER_SESSION_SECRET"']
+          imagePullPolicy: Always
+          env:
+            {{ include "ckan.environment-variables" . | nindent 12 }}
+            - name: CKAN_BEAKER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
+                  key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
+          volumeMounts:
+            - name: production-ini
+              mountPath: /map
+              readOnly: true
+            - name: config
+              mountPath: /config
       containers:
         - name: ckan
           image: {{ .Values.ckan.image }}
@@ -20,7 +38,7 @@ spec:
             - name: http
               containerPort: 5000
           volumeMounts:
-            - name: production-ini
+            - name: config
               mountPath: /config
               readOnly: true
           command: ["/bin/sh", "-c"]
@@ -31,3 +49,5 @@ spec:
         - name: production-ini
           configMap:
             name: {{ .Release.Name }}-ckan-production-ini
+        - name: config
+          emptyDir: {}

--- a/templates/ckan/serviceaccount.yaml
+++ b/templates/ckan/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.ckan.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ckan-service-account-{{ .Release.Name }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.ckan.serviceAccount.iamRoleARN }}
+{{- end }}

--- a/templates/ckan/serviceaccount.yaml
+++ b/templates/ckan/serviceaccount.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.ckan.serviceAccount.enabled }}
+{{- with .Values.ckan.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ckan-service-account-{{ .Release.Name }}
+  name: {{ .name | default (print "ckan-" $.Release.Name) }}
   annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.ckan.serviceAccount.iamRoleARN }}
+    eks.amazonaws.com/role-arn: {{ .iamRoleARN }}
+{{- end }}
 {{- end }}

--- a/templates/cronjobs/harvester-run.yaml
+++ b/templates/cronjobs/harvester-run.yaml
@@ -11,6 +11,7 @@ spec:
           containers:
             - name: ckan
               image: {{ .Values.ckan.image }}
+              imagePullPolicy: Always
               command: [ ckan, harvester, run ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}

--- a/templates/cronjobs/pycsw-load.yaml
+++ b/templates/cronjobs/pycsw-load.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-pycsw-load
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "0 * * * *"
   jobTemplate:
     spec:
       template:
@@ -12,6 +12,7 @@ spec:
           containers:
             - name: pycsw
               image: {{ .Values.pycsw.image }}
+              imagePullPolicy: Always
               command: [ "/bin/sh", "-c", "ckan ckan-pycsw load -p $CKAN_CONFIG/pycsw.cfg -u http://{{ .Release.Name }}-ckan:5000" ]
               env:
                 - name: PYCSW_CONFIG

--- a/templates/cronjobs/pycsw-load.yaml
+++ b/templates/cronjobs/pycsw-load.yaml
@@ -10,8 +10,8 @@ spec:
         spec:
           {{- include "ckan.pycsw-init" . | nindent 10 }}
           containers:
-            - name: ckan
-              image: {{ .Values.ckan.image }}
+            - name: pycsw
+              image: {{ .Values.pycsw.image }}
               command: [ "/bin/sh", "-c", "ckan ckan-pycsw load -p $CKAN_CONFIG/pycsw.cfg -u http://{{ .Release.Name }}-ckan:5000" ]
               env:
                 - name: PYCSW_CONFIG

--- a/templates/cronjobs/pycsw-run.yaml
+++ b/templates/cronjobs/pycsw-run.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-pycsw-load
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- include "ckan.pycsw-init" . | nindent 10 }}
+          containers:
+            - name: ckan
+              image: {{ .Values.ckan.image }}
+              command: [ "/bin/sh", "-c", "ckan ckan-pycsw load -p $CKAN_CONFIG/pycsw.cfg -u http://{{ .Release.Name }}-ckan:5000" ]
+              env:
+                - name: PYCSW_CONFIG
+                  value: /config/pycsw.cfg
+                {{ include "ckan.environment-variables" . | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+          restartPolicy: OnFailure
+          {{ include "ckan.pycsw-volumes" . | nindent 10 }}

--- a/templates/cronjobs/solr-index-rebuild.yaml
+++ b/templates/cronjobs/solr-index-rebuild.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
             - name: ckan
               image: {{ .Values.ckan.image }}
-              command: [ ckan, search-index, rebuild ]
+              command: [ ckan, search-index, rebuild, -r, --force ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}
               volumeMounts:

--- a/templates/cronjobs/solr-index-rebuild.yaml
+++ b/templates/cronjobs/solr-index-rebuild.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-solr-index-rebuild
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "0 * * * *"
   jobTemplate:
     spec:
       template:
@@ -11,6 +11,7 @@ spec:
           containers:
             - name: ckan
               image: {{ .Values.ckan.image }}
+              imagePullPolicy: Always
               command: [ ckan, search-index, rebuild, -r, --force ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}

--- a/templates/pycsw/configmap.yaml
+++ b/templates/pycsw/configmap.yaml
@@ -37,7 +37,7 @@ data:
 
     [server]
     home=/home/pycsw
-    url=http://localhost:8000/
+    url=${CKAN_SITE_URL}/csw
     mimetype=application/xml; charset=UTF-8
     encoding=UTF-8
     language=en-US
@@ -86,8 +86,7 @@ data:
 
     [repository]
     # postgres
-    #database=postgresql://username:password@localhost/pycsw
-    database=postgresql://ckan:ckan@ckan-test-postgres/pycsw
+    database=${CKAN_SQLALCHEMY_URL}
     table=records
 
     [metadata:inspire]

--- a/templates/pycsw/configmap.yaml
+++ b/templates/pycsw/configmap.yaml
@@ -43,7 +43,7 @@ data:
     language=en-US
     maxrecords=10
     loglevel=DEBUG
-    #logfile=
+    logfile=/dev/stdout
     #ogc_schemas_base=http://foo
     #federatedcatalogues=http://catalog.data.gov/csw
     #pretty_print=true

--- a/templates/pycsw/configmap.yaml
+++ b/templates/pycsw/configmap.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pycsw-cfg
+data:
+  pycsw.cfg: |
+    # =================================================================
+    #
+    # Authors: Tom Kralidis <tomkralidis@gmail.com>
+    #          Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
+    #
+    # Copyright (c) 2015 Tom Kralidis
+    # Copyright (c) 2017 Ricardo Garcia Silva
+    #
+    # Permission is hereby granted, free of charge, to any person
+    # obtaining a copy of this software and associated documentation
+    # files (the "Software"), to deal in the Software without
+    # restriction, including without limitation the rights to use,
+    # copy, modify, merge, publish, distribute, sublicense, and/or sell
+    # copies of the Software, and to permit persons to whom the
+    # Software is furnished to do so, subject to the following
+    # conditions:
+    #
+    # The above copyright notice and this permission notice shall be
+    # included in all copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    # HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    # OTHER DEALINGS IN THE SOFTWARE.
+    #
+    # =================================================================
+
+    [server]
+    home=/home/pycsw
+    url=http://localhost:8000/
+    mimetype=application/xml; charset=UTF-8
+    encoding=UTF-8
+    language=en-US
+    maxrecords=10
+    loglevel=DEBUG
+    #logfile=
+    #ogc_schemas_base=http://foo
+    #federatedcatalogues=http://catalog.data.gov/csw
+    #pretty_print=true
+    #gzip_compresslevel=8
+    #domainquerytype=range
+    #domaincounts=true
+    #spatial_ranking=true
+    profiles=apiso
+    #workers=2
+    timeout=30
+
+    [manager]
+    transactions=false
+    allowed_ips=127.0.0.1
+    #csw_harvest_pagesize=10
+
+    [metadata:main]
+    identification_title=pycsw Geospatial Catalogue
+    identification_abstract=pycsw is an OARec and OGC CSW server implementation written in Python
+    identification_keywords=catalogue,discovery,metadata
+    identification_keywords_type=theme
+    identification_fees=None
+    identification_accessconstraints=None
+    provider_name=Organization Name
+    provider_url=https://pycsw.org/
+    contact_name=Lastname, Firstname
+    contact_position=Position Title
+    contact_address=Mailing Address
+    contact_city=City
+    contact_stateorprovince=Administrative Area
+    contact_postalcode=Zip or Postal Code
+    contact_country=Country
+    contact_phone=+xx-xxx-xxx-xxxx
+    contact_fax=+xx-xxx-xxx-xxxx
+    contact_email=Email Address
+    contact_url=Contact URL
+    contact_hours=Hours of Service
+    contact_instructions=During hours of service.  Off on weekends.
+    contact_role=pointOfContact
+
+    [repository]
+    # postgres
+    #database=postgresql://username:password@localhost/pycsw
+    database=postgresql://ckan:ckan@ckan-test-postgres/pycsw
+    table=records
+
+    [metadata:inspire]
+    enabled=true
+    languages_supported=eng,gre
+    default_language=eng
+    date=YYYY-MM-DD
+    gemet_keywords=Utility and governmental services
+    conformity_service=notEvaluated
+    contact_name=Organization Name
+    contact_email=Email Address
+    temp_extent=YYYY-MM-DD/YYYY-MM-DD
+

--- a/templates/pycsw/ingress.yaml
+++ b/templates/pycsw/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.pycsw.ingress.enabled }}
+{{- with .Values.pycsw.ingress }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pycsw
+  {{- if not (empty .annotations) }}
+  annotations:
+    {{- toYaml .annotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  {{ if not (empty .ingressClassName) }}ingressClassName: {{ .ingressClassName }}{{ end }}
+  rules:
+    - host: {{ .host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-pycsw
+                port:
+                  number: 8000
+  {{- if .tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .host }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/pycsw/init-configmap.yaml
+++ b/templates/pycsw/init-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pycsw-init
+data:
+  init.sh: |
+    # copy config files first 
+    cp /map/production.ini /config
+    cp /pycsw/pycsw.cfg /config
+    cp $CKAN_VENV/src/ckan/who.ini /config
+
+    # update production.ini
+    ckan config-tool $CKAN_INI "ckan.plugins = harvest ckan_harvester spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester"
+    ckan config-tool $CKAN_INI "ckan.i18n_directory ="
+    ckan config-tool $CKAN_INI "who.config_file = /config/who.ini"

--- a/templates/pycsw/replicaset.yaml
+++ b/templates/pycsw/replicaset.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
         - name: config-set
           image: {{ .Values.ckan.image }}
-          command: [ "/bin/sh", "-c", '. /init/init.sh && python $CKAN_VENV/src/pycsw/pycsw/wsgi.py']
+          command: [ "/bin/sh", "-c", '. /init/init.sh']
           imagePullPolicy: Always
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
@@ -45,8 +45,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-          command: ["/bin/sh", "-c"]
-          args: ["tail -f /dev/null"]
+          command: ["/bin/sh", "-c", "python $CKAN_VENV/src/pycsw/pycsw/wsgi.py"]
           env:
             - name: PYCSW_CONFIG
               value: /config/pycsw.cfg

--- a/templates/pycsw/replicaset.yaml
+++ b/templates/pycsw/replicaset.yaml
@@ -12,29 +12,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-pycsw
     spec:
-      initContainers:
-        - name: config-set
-          image: {{ .Values.ckan.image }}
-          command: [ "/bin/sh", "-c", '. /init/init.sh']
-          imagePullPolicy: Always
-          env:
-            {{ include "ckan.environment-variables" . | nindent 12 }}
-            - name: CKAN_BEAKER_SESSION_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
-                  key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
-          volumeMounts:
-            - name: pycsw-cfg
-              mountPath: /pycsw
-              readOnly: true
-            - name: production-ini
-              mountPath: /map
-              readOnly: true
-            - name: config
-              mountPath: /config
-            - name: pycsw-init
-              mountPath: /init
+      {{- include "ckan.pycsw-init" . | nindent 6 }}
       containers:
         - name: pycsw
           image: {{ .Values.pycsw.image }}
@@ -50,15 +28,4 @@ spec:
             - name: PYCSW_CONFIG
               value: /config/pycsw.cfg
             {{ include "ckan.environment-variables" . | nindent 12 }}
-      volumes:
-        - name: pycsw-cfg
-          configMap:
-            name: {{ .Release.Name }}-pycsw-cfg
-        - name: pycsw-init
-          configMap:
-            name: {{ .Release.Name }}-pycsw-init
-        - name: production-ini
-          configMap:
-            name: {{ .Release.Name }}-ckan-production-ini
-        - name: config
-          emptyDir: {}
+      {{ include "ckan.pycsw-volumes" . | nindent 6 }}

--- a/templates/pycsw/replicaset.yaml
+++ b/templates/pycsw/replicaset.yaml
@@ -12,6 +12,29 @@ spec:
       labels:
         app: {{ .Release.Name }}-pycsw
     spec:
+      initContainers:
+        - name: config-set
+          image: {{ .Values.ckan.image }}
+          command: [ "/bin/sh", "-c", '. /init/init.sh && python $CKAN_VENV/src/pycsw/pycsw/wsgi.py']
+          imagePullPolicy: Always
+          env:
+            {{ include "ckan.environment-variables" . | nindent 12 }}
+            - name: CKAN_BEAKER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ckan.config.beakerSessionSecretKeyRef.name }}
+                  key: {{ .Values.ckan.config.beakerSessionSecretKeyRef.key }}
+          volumeMounts:
+            - name: pycsw-cfg
+              mountPath: /pycsw
+              readOnly: true
+            - name: production-ini
+              mountPath: /map
+              readOnly: true
+            - name: config
+              mountPath: /config
+            - name: pycsw-init
+              mountPath: /init
       containers:
         - name: pycsw
           image: {{ .Values.pycsw.image }}
@@ -20,15 +43,23 @@ spec:
             - name: http
               containerPort: 8000
           volumeMounts:
-            - name: pycsw-cfg
+            - name: config
               mountPath: /config
-              readOnly: true
-          # command: ["/bin/sh", "-c"]
-          # args: ["/ckan-entrypoint.sh && ckan run --host 0.0.0.0"]
+          command: ["/bin/sh", "-c"]
+          args: ["tail -f /dev/null"]
           env:
             - name: PYCSW_CONFIG
               value: /config/pycsw.cfg
+            {{ include "ckan.environment-variables" . | nindent 12 }}
       volumes:
         - name: pycsw-cfg
           configMap:
             name: {{ .Release.Name }}-pycsw-cfg
+        - name: pycsw-init
+          configMap:
+            name: {{ .Release.Name }}-pycsw-init
+        - name: production-ini
+          configMap:
+            name: {{ .Release.Name }}-ckan-production-ini
+        - name: config
+          emptyDir: {}

--- a/templates/pycsw/replicaset.yaml
+++ b/templates/pycsw/replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: {{ .Release.Name }}-pycsw
+spec:
+  replicas: {{ .Values.pycsw.count }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-pycsw
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-pycsw
+    spec:
+      containers:
+        - name: pycsw
+          image: {{ .Values.pycsw.image }}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+          volumeMounts:
+            - name: pycsw-cfg
+              mountPath: /config
+              readOnly: true
+          # command: ["/bin/sh", "-c"]
+          # args: ["/ckan-entrypoint.sh && ckan run --host 0.0.0.0"]
+          env:
+            - name: PYCSW_CONFIG
+              value: /config/pycsw.cfg
+      volumes:
+        - name: pycsw-cfg
+          configMap:
+            name: {{ .Release.Name }}-pycsw-cfg

--- a/templates/pycsw/service.yaml
+++ b/templates/pycsw/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-pycsw
+spec:
+  selector:
+    app: {{ .Release.Name }}-pycsw
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: http

--- a/templates/solr/deployment.yaml
+++ b/templates/solr/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-solr
     spec:
+      {{- if .Values.solr.persistence.enabled }}
       initContainers:
         - name: fix-volume-permissions
           image: {{ .Values.solr.image }}
@@ -22,6 +23,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+      {{- end }}
       containers:
         - name: solr
           image: {{ .Values.solr.image }}

--- a/templates/solr/deployment.yaml
+++ b/templates/solr/deployment.yaml
@@ -12,6 +12,16 @@ spec:
       labels:
         app: {{ .Release.Name }}-solr
     spec:
+      initContainers:
+        - name: fix-volume-permissions
+          image: {{ .Values.solr.image }}
+          command: [ bash, -c, "chown -R solr:solr /data" ]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
       containers:
         - name: solr
           image: {{ .Values.solr.image }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,9 @@
 ckan:
   count: 1
   image: ghcr.io/kentsanggds/ckan:2.9.7
+  serviceAccount:
+    enabled: false
+    iamRoleARN: ""
   config:
     site:
       id: "dgu"
@@ -11,6 +14,7 @@ ckan:
     sqlalchemyUrlSecretKeyRef:
       name: ckan
       key: sqlalchemy_url
+    dbHost: ""
     redis:
       host: ""
       port: "6379"
@@ -33,12 +37,17 @@ ckan:
       mailFrom: ""
       starttls: "False"
     s3:
-      bucket_name: ""
-      url_prefix: ""
-      region_name: ""
+      useIamServiceAccount: false
+      bucketName: ""
+      urlPrefix: ""
+      regionName: ""
       credentials:
-        access_key_id: ""
-        secret_access_key: ""
+        awsAccessKeyIdSecretKeyRef:
+          name: ckan
+          key: aws_access_key_id
+        awsSecretAccessKeySecretKeyRef:
+          name: ckan
+          key: aws_secret_access_key
     
 
 solr:

--- a/values.yaml
+++ b/values.yaml
@@ -79,3 +79,14 @@ gather:
   count: 1
 fetch:
   count: 1
+  
+pycsw:
+  count: 1
+  image: ghcr.io/geopython/pycsw
+  ingress:
+    enabled: true
+    host: pycsw.data.gov.uk
+    ingressClassName: ""
+    annotations:
+    tls:
+      enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,9 @@ ckan:
       host: ""
       port: "6379"
       db_number: "1"
+    beakerSessionSecretKeyRef:
+      name: ckan
+      key: beaker_session_secret
     solr:
       url: ""
       user: ""

--- a/values.yaml
+++ b/values.yaml
@@ -48,11 +48,10 @@ ckan:
         awsSecretAccessKeySecretKeyRef:
           name: ckan
           key: aws_secret_access_key
-    
 
 solr:
   enabled: true
-  image: ghcr.io/samsimpson1/solr
+  image: ghcr.io/kentsanggds/solr:6.6.2
   persistence:
     enabled: false
     persistentVolumeClaimName: "solr"
@@ -79,10 +78,10 @@ gather:
   count: 1
 fetch:
   count: 1
-  
+
 pycsw:
   count: 1
-  image: ghcr.io/geopython/pycsw
+  image: ghcr.io/kentsanggds/pycsw:2.6.1
   ingress:
     enabled: true
     host: pycsw.data.gov.uk


### PR DESCRIPTION
## What

This PR includes - 

- management of beaker session secrets for CKAN
- settings for deploying onto the integration cluster
- user of service account on the integration cluster to access s3 buckets
- setting up of the pycsw web server and cronjob to load data from CKAN
- update of the solr reindex to do a refresh and force it to continue even if the data is invalid

## Reference 

https://trello.com/c/2v4P7LAO/1073-create-ckan-helm-chart-to-run-on-local-cluster
https://trello.com/c/CxQutDOt/1115-update-ckan-helm-chart-to-run-on-integration-cluster
