### PR TITLE
Use datagovuk reindex_recent

### DIFF
--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -12,7 +12,7 @@ spec:
             - name: ckan
               image: {{ .Values.ckan.image }}
               imagePullPolicy: Always
-              command: [ ckan, search-index, rebuild, -r, --force ]
+              command: [ ckan, datagovuk, reindex-recent ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}
               volumeMounts:


### PR DESCRIPTION
## What

- only reindex last 24 hours rather than all the datasets to speed up processing

## Reference 

https://trello.com/c/GnDhUN6u/1140-improve-solr-reindexing-and-pycsw-load-efficiency