### PR TITLE
Use CKAN search-index rebuild

### DIFF
--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -12,7 +12,7 @@ spec:
             - name: ckan
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
               imagePullPolicy: Always
-              command: [ ckan, datagovuk, reindex-recent ]
+              command: [ ckan, search-index, rebuild, -r ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}
               volumeMounts:


### PR DESCRIPTION
Using the option -r ensures that the search index is not recreated each time but just refreshes.