### PR TITLE
Ignore search-index rebuild errors

### DIFF
--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -12,7 +12,7 @@ spec:
             - name: ckan
               image: '{{ include "docker-uri" (dict "environment" .Values.environment "app" "ckan" "files" $.Files) }}'
               imagePullPolicy: Always
-              command: [ ckan, search-index, rebuild, -r ]
+              command: [ ckan, search-index, rebuild, -r, -i ]
               env:
                 {{- include "ckan.environment-variables" . | nindent 16 }}
               volumeMounts:


### PR DESCRIPTION
Errors will be output in log file, do not stop the process if an error is found in an index, just continue to next index.