### PR TITLE
Change the solr data mount path

### DIFF
--- a/charts/ckan/templates/solr/deployment.yaml
+++ b/charts/ckan/templates/solr/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           {{- if .Values.solr.persistence.enabled }}
           volumeMounts:
             - name: data
-              mountPath: /opt/solr/server/solr/ckan/data
+              mountPath: /var/solr/data
           {{- end }}
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## What 

Upgrading to use ckan-solr 8 meant that the location of the data stored was incorrectly configured causing the search indexes to be lost between deployments. 

This update should fix that problem with the correct mount path

## Reference

https://trello.com/c/MfGZLLyD/1208-investigate-and-fix-issue-with-search-index-removing-datasets-upon-deployment