### PR TITLE
Increase CKAN gunicorn timeout to 120

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /config
               readOnly: true
           command: ["/bin/sh", "-c"]
-          args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application"]
+          args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
CKAN was timing out on a number of pages in integration as the pages took >30 seconds to render, so increase the timeout.

This behaviour is similar to the existing integration stack, so no worse performance wise.