### PR TITLE
Add Staging cluster and probes to fix issues with CKAN

### DIFF
--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -5,7 +5,7 @@ ckanHelmValues:
       command:
         args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
       probes:
-        enabled: false
+        enabled: true
       site:
         url: "https://ckan.eks.integration.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -2,6 +2,8 @@ ckanHelmValues:
   environment: integration
   ckan:
     config:
+      command:
+        args: "gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"
       site:
         url: "https://ckan.eks.integration.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -3,7 +3,7 @@ ckanHelmValues:
   ckan:
     config:
       command:
-        args: "gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"
+        args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
       site:
         url: "https://ckan.eks.integration.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-integration.yaml
+++ b/charts/app-of-apps/values-integration.yaml
@@ -4,6 +4,8 @@ ckanHelmValues:
     config:
       command:
         args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
+      probes:
+        enabled: false
       site:
         url: "https://ckan.eks.integration.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -1,0 +1,51 @@
+ckanHelmValues:
+  environment: staging
+  ckan:
+    config:
+      site:
+        url: "https://ckan.eks.staging.govuk.digital"
+        title: "data.gov.uk"
+      dbHost: "ckan-postgres.staging.govuk-internal.digital"
+      redis:
+        host: "backend-redis.staging.govuk-internal.digital"
+      smtp:
+        server: "email-smtp.eu-west-1.amazonaws.com:587"
+        user: "AKIA2EQZDNSGRK55CPNS"
+        mailFrom: "team@data.gov.uk"
+        starttls: "True"
+      s3:
+        useIamServiceAccount: true
+        bucketName: "datagovuk-staging-ckan-organogram"
+        regionName: "eu-west-1"
+        urlPrefix: "https://s3-eu-west-1.amazonaws.com/datagovuk-staging-ckan-organogram/"
+    serviceAccount:
+      enabled: true
+      name: ckan
+      iamRoleARN: arn:aws:iam::696911096973:role/ckan-govuk
+  solr:
+    enabled: true
+    persistence:
+      enabled: true
+      persistentVolumeClaimName: solr
+  postgres:
+    enabled: false
+  redis:
+    enabled: false
+  ingress:
+    host: ckan.eks.staging.govuk.digital
+    ingressClassName: aws-alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/ssl-redirect: "443"
+    tls:
+      enabled: true
+  dev:
+    enabled: false
+  gather:
+    count: 1
+  fetch:
+    count: 1
+  externalSecret:
+    enabled: true

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -5,7 +5,7 @@ ckanHelmValues:
       command:
         args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
       probes:
-        enabled: false
+        enabled: true
       site:
         url: "https://ckan.eks.staging.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -4,6 +4,8 @@ ckanHelmValues:
     config:
       command:
         args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
+      probes:
+        enabled: false
       site:
         url: "https://ckan.eks.staging.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -2,6 +2,8 @@ ckanHelmValues:
   environment: staging
   ckan:
     config:
+      command:
+        args: "gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"
       site:
         url: "https://ckan.eks.staging.govuk.digital"
         title: "data.gov.uk"

--- a/charts/app-of-apps/values-staging.yaml
+++ b/charts/app-of-apps/values-staging.yaml
@@ -3,7 +3,7 @@ ckanHelmValues:
   ckan:
     config:
       command:
-        args: "gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"
+        args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
       site:
         url: "https://ckan.eks.staging.govuk.digital"
         title: "data.gov.uk"

--- a/charts/ckan/images/staging/ckan.yaml
+++ b/charts/ckan/images/staging/ckan.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/ckan
+tag: 4f62302e5ab311f4493e9db1808d288ad22b25a0
+branch: main

--- a/charts/ckan/images/staging/pycsw.yaml
+++ b/charts/ckan/images/staging/pycsw.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/pycsw
+tag: 4f62302e5ab311f4493e9db1808d288ad22b25a0
+branch: main

--- a/charts/ckan/images/staging/solr.yaml
+++ b/charts/ckan/images/staging/solr.yaml
@@ -1,0 +1,3 @@
+repository: ghcr.io/alphagov/solr
+tag: 4f62302e5ab311f4493e9db1808d288ad22b25a0
+branch: main

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /config
               readOnly: true
           command: ["/bin/sh", "-c"]
-          args: ["gunicorn --bind 0.0.0.0:5000 wsgi:application --timeout 120"]
+          args: [{{ .Values.ckan.config.command.args }}]
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
           livenessProbe:

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -64,6 +64,7 @@ spec:
           args: {{ .Values.ckan.config.command.args }}
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
+          {{- if .Values.ckan.config.probes.enabled }}
           livenessProbe:
             httpGet:
               path: /healthcheck
@@ -79,6 +80,7 @@ spec:
             failureThreshold: 60
             periodSeconds: 120
             timeoutSeconds: 60
+          {{- end }}
       volumes:
         - name: ckan-init
           configMap:

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
+            initialDelaySeconds: 600
             periodSeconds: 60
             timeoutSeconds: 30
           startupProbe:

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -68,8 +68,16 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 3
+            periodSeconds: 60
+            timeoutSeconds: 30
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            initialDelaySeconds: 600
+            failureThreshold: 60
+            periodSeconds: 120
+            timeoutSeconds: 60
       volumes:
         - name: ckan-init
           configMap:

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /config
               readOnly: true
           command: ["/bin/sh", "-c"]
-          args: [{{ .Values.ckan.config.command.args }}]
+          args: {{ .Values.ckan.config.command.args }}
           env:
             {{ include "ckan.environment-variables" . | nindent 12 }}
           livenessProbe:

--- a/charts/ckan/templates/solr/pvc.yaml
+++ b/charts/ckan/templates/solr/pvc.yaml
@@ -7,7 +7,6 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
 {{- end }}

--- a/charts/ckan/templates/solr/pvc.yaml
+++ b/charts/ckan/templates/solr/pvc.yaml
@@ -1,0 +1,13 @@
+{{- if not $.Values.dev.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: solr
+spec:
+  resources:
+    requests:
+      storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+{{- end }}

--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -8,8 +8,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-solr
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:

--- a/charts/ckan/templates/solr/statefulset.yaml
+++ b/charts/ckan/templates/solr/statefulset.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.solr.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-solr
 spec:
+  serviceName: "solr"
   selector:
     matchLabels:
       app: {{ .Release.Name }}-solr

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -5,7 +5,7 @@ ckan:
     iamRoleARN: ""
   config:
     command:
-      args: "ckan run --host 0.0.0.0"
+      args: ["ckan run --host 0.0.0.0"]
     site:
       id: "dgu"
       url: "http://dev.data.gov.uk:8081"

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -6,6 +6,8 @@ ckan:
   config:
     command:
       args: ["ckan run --host 0.0.0.0"]
+    probes:
+      enabled: false
     site:
       id: "dgu"
       url: "http://dev.data.gov.uk:8081"

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -4,6 +4,8 @@ ckan:
     enabled: false
     iamRoleARN: ""
   config:
+    command:
+      args: "ckan run --host 0.0.0.0"
     site:
       id: "dgu"
       url: "http://dev.data.gov.uk:8081"


### PR DESCRIPTION
## What

This PR contains a number of fixes because I was trying to improve the resilience of the website which was crashing a lot.

- Add a startupProbe to improve success of livenessProbe which appeared to be failing due to the long times to start up
- Add staging files so that we can use the data hosted in the staging environment
- Create a solr PVC managed by the chart 
- Move the run command args to environment values yaml as this will allow devs to change the startup command in an environment to investigate things.

It looks like there is an issue with the integration environment which might be data related and there is an issue with the auth login / logout as this causes timeouts on integration and staging. This will be worked on in another branch / PR.

## Reference 

https://trello.com/c/XiwdEug1/1209-investigate-and-fix-ckan-pod-restarts-in-cluster