### PR TITLE
Only run cronjobs between 8am - 10pm

### DIFF
--- a/charts/ckan/templates/cronjobs/harvester-run.yaml
+++ b/charts/ckan/templates/cronjobs/harvester-run.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-harvester-run
 spec:
-  schedule: "0 * * * *"
+  schedule: "0 8-22 * * *"
   jobTemplate:
     spec:
       template:

--- a/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
+++ b/charts/ckan/templates/cronjobs/solr-index-rebuild.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-solr-index-rebuild
 spec:
-  schedule: "0 * * * *"
+  schedule: "0 8-22 * * *"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
As it looks like the runs are causing db locks when the env sync process runs.