### PR TITLE
Add a readiness prob in case the container is too busy to receive requests

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -60,7 +60,6 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
-          # command: {{ .Values.ckan.command }}
           command: ["/bin/sh", "-c"]
           args: {{ .Values.ckan.args }}
           env:

--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -70,9 +70,14 @@ spec:
             httpGet:
               path: /healthcheck
               port: http
-            initialDelaySeconds: 600
             periodSeconds: 60
             timeoutSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
           startupProbe:
             httpGet:
               path: /healthcheck


### PR DESCRIPTION
Removing the initial delay to the liveness probe and adding a readiness probe appears to have stabilised the CKAN pod. 