### PR TITLE
Update readiness and startup probes

### DIFF
--- a/charts/ckan/templates/ckan/deployment.yaml
+++ b/charts/ckan/templates/ckan/deployment.yaml
@@ -76,14 +76,15 @@ spec:
               path: /healthcheck
               port: http
             periodSeconds: 5
-            timeoutSeconds: 5
+            successThreshold: 3
+            timeoutSeconds: 10
           startupProbe:
             httpGet:
               path: /healthcheck
               port: http
-            initialDelaySeconds: 600
+            initialDelaySeconds: 60
             failureThreshold: 60
-            periodSeconds: 120
+            periodSeconds: 10
             timeoutSeconds: 60
           {{- end }}
       volumes:


### PR DESCRIPTION
The readinessProb readinessThreshold and timeoutSeconds was too low, it was causing the pod to be restarted so incease the times allowed for timeout and a successful check.

Also the startpProbe of initialDelay of 600 seconds would mean that any change to the pod would take at least 10 minutes to take effect so reduce this to 10 seconds.